### PR TITLE
dev->main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 ## Changelog
 
+### v0.1.1 - Feb 2025
+ - Fix deprecated features which were removed in HA Core 2025.1 https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation:
+    - TEMP_CELSIUS was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead
+    - TEMP_FAHRENHEIT was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.FAHRENHEIT instead
+    - HVAC_MODE_OFF was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.OFF instead
+    - HVAC_MODE_HEAT was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.HEAT instead
+    - CURRENT_HVAC_OFF was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.OFF instead,
+    - CURRENT_HVAC_HEAT was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.HEATING instead
+    - CURRENT_HVAC_IDLE was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.IDLE instead
+    - SUPPORT_TARGET_TEMPERATURE was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use ClimateEntityFeature.TARGET_TEMPERATURE instead. Entity None (<class 'custom_components.heatmiser_wifi.climate.HeatmiserWifi'>) is using deprecated supported features values which will be removed in HA Core 2025.1. Instead it should use <ClimateEntityFeature.TARGET_TEMPERATURE|PRESET_MODE https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation
+
 ### v0.1.0 - May 2024
  - First release of my forked version from the original (https://github.com/midstar/heatmiser_wifi_ha)
-
-### v0.1.1 - Feb 2025
- - Fix deprecated features which were removed in HA Core 2025.1:
-    - Entity None (<class 'custom_components.heatmiser_wifi.climate.HeatmiserWifi'>) is using deprecated supported features values which will be removed in HA Core 2025.1. Instead it should use <ClimateEntityFeature.TARGET_TEMPERATURE|PRESET_MODE https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation
-    - TEMP_CELSIUS was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead, please report it to the author of the 'heatmiser_wifi' custom integration
-    - TEMP_FAHRENHEIT was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.FAHRENHEIT instead, please report it to the author of the 'heatmiser_wifi' custom integration
-    - HVAC_MODE_OFF was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.OFF instead, please report it to the author of the 'heatmiser_wifi' custom integration
-    - HVAC_MODE_HEAT was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.HEAT instead, please report it to the author of the 'heatmiser_wifi' custom integration
-    - CURRENT_HVAC_OFF was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.OFF instead, please report it to the author of the 'heatmiser_wifi' custom integration
-    - CURRENT_HVAC_HEAT was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.HEATING instead, please report it to the author of the 'heatmiser_wifi' custom integration
-    - CURRENT_HVAC_IDLE was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.IDLE instead, please report it to the author of the 'heatmiser_wifi' custom integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,23 @@
 ## Changelog
 
 ### v0.1.1 - Feb 2025
- - Fix deprecated features which were removed in HA Core 2025.1 https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation:
-    - TEMP_CELSIUS was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead
-    - TEMP_FAHRENHEIT was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.FAHRENHEIT instead
-    - HVAC_MODE_OFF was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.OFF instead
-    - HVAC_MODE_HEAT was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.HEAT instead
-    - CURRENT_HVAC_OFF was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.OFF instead,
-    - CURRENT_HVAC_HEAT was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.HEATING instead
-    - CURRENT_HVAC_IDLE was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.IDLE instead
-    - SUPPORT_TARGET_TEMPERATURE was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use ClimateEntityFeature.TARGET_TEMPERATURE instead. Entity None (<class 'custom_components.heatmiser_wifi.climate.HeatmiserWifi'>) is using deprecated supported features values which will be removed in HA Core 2025.1. Instead it should use <ClimateEntityFeature.TARGET_TEMPERATURE|PRESET_MODE https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation
+
+   - Fix deprecated features which were removed in HA Core 2025.1 https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation:
+      - TEMP_CELSIUS was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead
+      - TEMP_FAHRENHEIT was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.FAHRENHEIT instead
+      - HVAC_MODE_OFF was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.OFF instead
+      - HVAC_MODE_HEAT was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.HEAT instead
+      - CURRENT_HVAC_OFF was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.OFF instead
+      - CURRENT_HVAC_HEAT was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.HEATING instead
+      - CURRENT_HVAC_IDLE was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.IDLE instead
+      - SUPPORT_TARGET_TEMPERATURE was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use ClimateEntityFeature.TARGET_TEMPERATURE instead
+
+   - Fix deprecated features which will be removed in HA Core 2025.5:
+      - Detected that custom integration 'heatmiser_wifi' accesses hass.helpers.discovery, which should be updated to import functions used from discovery directly at custom_components/heatmiser_wifi/__init__.py, line 55: hass.helpers.discovery.load_platform('climate', DOMAIN, {}, config)
+
+   - Fix other errors / warnings in the logs:
+      - Error adding entity sensor.prt_hw_air_temp for domain sensor with platform heatmiser_wifi
+
 
 ### v0.1.0 - May 2024
  - First release of my forked version from the original (https://github.com/midstar/heatmiser_wifi_ha)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## Changelog
 
-### v0.1.1 - May 2024
+### v0.1.0 - May 2024
  - First release of my forked version from the original (https://github.com/midstar/heatmiser_wifi_ha)
 
-### v0.1.2 - Feb 2025
+### v0.1.1 - Feb 2025
  - Fix deprecated features which were removed in HA Core 2025.1:
     - Entity None (<class 'custom_components.heatmiser_wifi.climate.HeatmiserWifi'>) is using deprecated supported features values which will be removed in HA Core 2025.1. Instead it should use <ClimateEntityFeature.TARGET_TEMPERATURE|PRESET_MODE https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation
     - TEMP_CELSIUS was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead, please report it to the author of the 'heatmiser_wifi' custom integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+## Changelog
+
+### v0.1.1 - May 2024
+ - First release of my forked version from the original (https://github.com/midstar/heatmiser_wifi_ha)
+
+### v0.1.2 - Feb 2025
+ - Fix deprecated features which were removed in HA Core 2025.1:
+    - Entity None (<class 'custom_components.heatmiser_wifi.climate.HeatmiserWifi'>) is using deprecated supported features values which will be removed in HA Core 2025.1. Instead it should use <ClimateEntityFeature.TARGET_TEMPERATURE|PRESET_MODE https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation
+    - TEMP_CELSIUS was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead, please report it to the author of the 'heatmiser_wifi' custom integration
+    - TEMP_FAHRENHEIT was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.FAHRENHEIT instead, please report it to the author of the 'heatmiser_wifi' custom integration
+    - HVAC_MODE_OFF was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.OFF instead, please report it to the author of the 'heatmiser_wifi' custom integration
+    - HVAC_MODE_HEAT was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.HEAT instead, please report it to the author of the 'heatmiser_wifi' custom integration
+    - CURRENT_HVAC_OFF was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.OFF instead, please report it to the author of the 'heatmiser_wifi' custom integration
+    - CURRENT_HVAC_HEAT was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.HEATING instead, please report it to the author of the 'heatmiser_wifi' custom integration
+    - CURRENT_HVAC_IDLE was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.IDLE instead, please report it to the author of the 'heatmiser_wifi' custom integration

--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ Add following configuration to Home Assistant configuration.yaml
 * [daveNewcastle/Heatmiser-WIFI](https://github.com/daveNewcastle/Heatmiser-WIFI) Heatmiser Wifi Home Assistant Component for older versions of Home Assistant. It has not been updated for many years.
 * [Home Assistant Heatmiser Core component](https://www.home-assistant.io/integrations/heatmiser/) for non WiFi versions of Heatmister Thermostats.
  
-### Author and license
+## Author and license
 This component was originally written by Joel Midstjärna and licensed under the MIT License. This fork is updated by Iain Bullock and licensed under the MIT License.

--- a/custom_components/heatmiser_wifi/__init__.py
+++ b/custom_components/heatmiser_wifi/__init__.py
@@ -53,11 +53,6 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     heatmiser.disconnect()
 
-    #hass.helpers.discovery.load_platform('climate', DOMAIN, {}, config)
-    #hass.helpers.discovery.load_platform('sensor', DOMAIN, {}, config)
-    #hass.helpers.discovery.load_platform('switch', DOMAIN, {}, config)
-    #hass.helpers.discovery.load_platform('number', DOMAIN, {}, config)
-
     load_platform(hass, 'climate', DOMAIN, {}, config)
     load_platform(hass, 'sensor', DOMAIN, {}, config)
     load_platform(hass, 'switch', DOMAIN, {}, config)

--- a/custom_components/heatmiser_wifi/__init__.py
+++ b/custom_components/heatmiser_wifi/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.discovery import load_platform
 from heatmiser_wifi import Heatmiser
 from homeassistant.components.climate import (ClimateEntity)
 
@@ -52,10 +53,15 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     heatmiser.disconnect()
 
-    hass.helpers.discovery.load_platform('climate', DOMAIN, {}, config)
-    hass.helpers.discovery.load_platform('sensor', DOMAIN, {}, config)
-    hass.helpers.discovery.load_platform('switch', DOMAIN, {}, config)
-    hass.helpers.discovery.load_platform('number', DOMAIN, {}, config)
+    #hass.helpers.discovery.load_platform('climate', DOMAIN, {}, config)
+    #hass.helpers.discovery.load_platform('sensor', DOMAIN, {}, config)
+    #hass.helpers.discovery.load_platform('switch', DOMAIN, {}, config)
+    #hass.helpers.discovery.load_platform('number', DOMAIN, {}, config)
+
+    load_platform(hass, 'climate', DOMAIN, {}, config)
+    load_platform(hass, 'sensor', DOMAIN, {}, config)
+    load_platform(hass, 'switch', DOMAIN, {}, config)
+    load_platform(hass, 'number', DOMAIN, {}, config)
 
     def set_value(call):
         name = call.data.get("name")

--- a/custom_components/heatmiser_wifi/climate.py
+++ b/custom_components/heatmiser_wifi/climate.py
@@ -40,7 +40,7 @@ class HeatmiserWifi(ClimateEntity):
 
     @property
     def supported_features(self):
-        return ClimateEntityFeature.TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
+        return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
 
     @property
     def temperature_unit(self):

--- a/custom_components/heatmiser_wifi/climate.py
+++ b/custom_components/heatmiser_wifi/climate.py
@@ -12,8 +12,7 @@ from homeassistant.components.climate.const import (
     CURRENT_HVAC_IDLE, PRESET_HOME, PRESET_AWAY)
 
 from homeassistant.const import (
-    TEMP_CELSIUS, TEMP_FAHRENHEIT, 
-    ATTR_FRIENDLY_NAME, ATTR_TEMPERATURE)
+    ATTR_FRIENDLY_NAME, ATTR_TEMPERATURE, UnitOfTemperature)
 
 import logging
 _LOGGER = logging.getLogger(__name__)
@@ -48,8 +47,8 @@ class HeatmiserWifi(ClimateEntity):
     @property
     def temperature_unit(self):
         if self.hass.data[DOMAIN]['heatmiser_info']['temperature_format'] == 'Celsius':
-            return TEMP_CELSIUS
-        return TEMP_FAHRENHEIT
+            return UnitOfTemperature.CELSIUS
+        return UnitOfTemperature.FAHRENHEIT
 
     @property
     def current_temperature(self):

--- a/custom_components/heatmiser_wifi/climate.py
+++ b/custom_components/heatmiser_wifi/climate.py
@@ -7,9 +7,8 @@ from heatmiser_wifi import Heatmiser
 from homeassistant.components.climate import (ClimateEntity)
 
 from homeassistant.components.climate.const import (
-    SUPPORT_TARGET_TEMPERATURE, SUPPORT_PRESET_MODE, HVAC_MODE_OFF,
-    HVAC_MODE_HEAT, CURRENT_HVAC_OFF, CURRENT_HVAC_HEAT,
-    CURRENT_HVAC_IDLE, PRESET_HOME, PRESET_AWAY)
+    SUPPORT_TARGET_TEMPERATURE, SUPPORT_PRESET_MODE, CURRENT_HVAC_OFF, CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_IDLE, PRESET_HOME, PRESET_AWAY, HVACMode)
 
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME, ATTR_TEMPERATURE, UnitOfTemperature)
@@ -87,12 +86,12 @@ class HeatmiserWifi(ClimateEntity):
     @property
     def hvac_mode(self):
         if self.hass.data[DOMAIN]['heatmiser_info']['on_off'] == 'Off':
-            return HVAC_MODE_OFF
-        return HVAC_MODE_HEAT
+            return HVACMode.OFF
+        return HVACMode.HEAT
 
     @property
     def hvac_modes(self):
-        return [HVAC_MODE_OFF, HVAC_MODE_HEAT]
+        return [HVACMode.OFF, HVACMode.HEAT]
 
     @property
     def preset_mode(self):
@@ -127,9 +126,9 @@ class HeatmiserWifi(ClimateEntity):
 
     def set_hvac_mode(self, hvac_mode):
         on_off = 'On'
-        if hvac_mode == HVAC_MODE_OFF:
+        if hvac_mode == HVACMode.OFF:
             on_off = 'Off'
-        elif hvac_mode != HVAC_MODE_HEAT:
+        elif hvac_mode != HVACMode.HEAT:
             return # Invalid mode return
         self.hass.data[DOMAIN]['heatmiser'].connect()
         self.hass.data[DOMAIN]['heatmiser'].set_value('on_off', on_off)

--- a/custom_components/heatmiser_wifi/climate.py
+++ b/custom_components/heatmiser_wifi/climate.py
@@ -7,8 +7,8 @@ from heatmiser_wifi import Heatmiser
 from homeassistant.components.climate import (ClimateEntity)
 
 from homeassistant.components.climate.const import (
-    SUPPORT_TARGET_TEMPERATURE, SUPPORT_PRESET_MODE, CURRENT_HVAC_OFF, CURRENT_HVAC_HEAT,
-    CURRENT_HVAC_IDLE, PRESET_HOME, PRESET_AWAY, HVACMode)
+    SUPPORT_TARGET_TEMPERATURE, SUPPORT_PRESET_MODE,
+    PRESET_HOME, PRESET_AWAY, HVACMode, HVACAction)
 
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME, ATTR_TEMPERATURE, UnitOfTemperature)
@@ -111,10 +111,10 @@ class HeatmiserWifi(ClimateEntity):
     @property
     def hvac_action(self):
         if self.hass.data[DOMAIN]['heatmiser_info']['on_off'] == 'Off':
-            return CURRENT_HVAC_OFF
+            return HVACAction.OFF
         elif self.hass.data[DOMAIN]['heatmiser_info']['heating_is_currently_on']:
-            return CURRENT_HVAC_HEAT
-        return CURRENT_HVAC_IDLE
+            return HVACAction.HEATING
+        return HVACAction.IDLE
 
     def set_temperature(self, **kwargs):
         temperature = kwargs.get(ATTR_TEMPERATURE)

--- a/custom_components/heatmiser_wifi/climate.py
+++ b/custom_components/heatmiser_wifi/climate.py
@@ -7,8 +7,7 @@ from heatmiser_wifi import Heatmiser
 from homeassistant.components.climate import (ClimateEntity)
 
 from homeassistant.components.climate.const import (
-    SUPPORT_TARGET_TEMPERATURE, SUPPORT_PRESET_MODE,
-    PRESET_HOME, PRESET_AWAY, HVACMode, HVACAction)
+    PRESET_HOME, PRESET_AWAY, HVACMode, HVACAction, ClimateEntityFeature)
 
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME, ATTR_TEMPERATURE, UnitOfTemperature)
@@ -41,7 +40,7 @@ class HeatmiserWifi(ClimateEntity):
 
     @property
     def supported_features(self):
-        return SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
+        return ClimateEntityFeature.TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
 
     @property
     def temperature_unit(self):

--- a/custom_components/heatmiser_wifi/manifest.json
+++ b/custom_components/heatmiser_wifi/manifest.json
@@ -6,9 +6,9 @@
     "dependencies": [],
     "after_dependencies": [],
     "codeowners": [
-      "@midstar", "@iainbullock"
+      "@iainbullock"
     ],
     "requirements": ["heatmiser_wifi"],
-    "version": "1.1.0",
+    "version": "1.1.1",
     "iot_class": "local_polling"
   }

--- a/custom_components/heatmiser_wifi/sensor.py
+++ b/custom_components/heatmiser_wifi/sensor.py
@@ -181,9 +181,9 @@ class air_temp_sensor(SensorEntity):
     def name(self) -> str:
         return self.hass.data[DOMAIN]['name'] + '_air_temp'
 
-    @property
-    def device_class(self) -> str:
-        return SensorDeviceClass.TEMPERATURE
+    #@property
+    #def device_class(self) -> str:
+    #    return SensorDeviceClass.TEMPERATURE
 
     @property
     def suggested_unit_of_measurement(self) -> str:


### PR DESCRIPTION
## v0.1.1 - Feb 2025

   - Fix deprecated features which were removed in HA Core 2025.1 https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation:
      - TEMP_CELSIUS was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead
      - TEMP_FAHRENHEIT was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.FAHRENHEIT instead
      - HVAC_MODE_OFF was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.OFF instead
      - HVAC_MODE_HEAT was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.HEAT instead
      - CURRENT_HVAC_OFF was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.OFF instead
      - CURRENT_HVAC_HEAT was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.HEATING instead
      - CURRENT_HVAC_IDLE was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACAction.IDLE instead
      - SUPPORT_TARGET_TEMPERATURE was used from heatmiser_wifi, this is a deprecated constant which will be removed in HA Core 2025.1. Use ClimateEntityFeature.TARGET_TEMPERATURE instead

   - Fix deprecated features which will be removed in HA Core 2025.5:
      - Detected that custom integration 'heatmiser_wifi' accesses hass.helpers.discovery, which should be updated to import functions used from discovery directly at custom_components/heatmiser_wifi/__init__.py, line 55: hass.helpers.discovery.load_platform('climate', DOMAIN, {}, config)

   - Fix other errors / warnings in the logs:
      - Error adding entity sensor.prt_hw_air_temp for domain sensor with platform heatmiser_wifi